### PR TITLE
Added Epic Support.

### DIFF
--- a/bin/create_db.rb
+++ b/bin/create_db.rb
@@ -6,7 +6,7 @@ db = PG.connect(dbname: ARGV.first)
 
 # Create platform enum. (switch not supported atm)
 db.exec(<<~SQL)
-  create type platform as ENUM ('steam', 'xbox', 'ps', 'switch')
+  create type platform as ENUM ('steam', 'xbox', 'ps', 'switch', 'epic')
 SQL
 
 # Create users table.

--- a/documentation/commands.json
+++ b/documentation/commands.json
@@ -7,7 +7,7 @@
     "usage": "<account-id> [platform]",
     "arg_notes": [
       "`account-id` may be a string or number, depending on platform.",
-      "`platform` must be one of `ps|xbox|steam`.  Defaults to `steam`."
+      "`platform` must be one of `ps|xbox|steam|epic`.  Defaults to `steam`."
     ]
   },
   "unregister": {

--- a/lib/RLBot.rb
+++ b/lib/RLBot.rb
@@ -13,7 +13,7 @@ class RLBot
   include Singleton
 
   ##### PRIVATE CONSTANTS #####
-  PLATFORMS = %i[steam xbox ps].freeze
+  PLATFORMS = %i[steam xbox ps epic].freeze
   private_constant :PLATFORMS
   #############################
 
@@ -196,7 +196,8 @@ class RLBot
     return RLUtils.link(member, {
       steam: 'https://rlstats.net/profile/Steam/',
       xbox: 'https://rlstats.net/profile/Xbox/',
-      ps: 'https://rlstats.net/profile/PS4/'
+      ps: 'https://rlstats.net/profile/PS4/',
+      epic: 'https://rlstats.net/profile/Epic/'
     })
   end
 
@@ -204,7 +205,8 @@ class RLBot
     return RLUtils.link(member, {
       steam: 'http://rocketleague.tracker.network/profile/steam/',
       xbox: 'https://rocketleague.tracker.network/profile/xbox/',
-      ps: 'https://rocketleague.tracker.network/profile/ps/'
+      ps: 'https://rocketleague.tracker.network/profile/ps/',
+      epic: 'https://rocketleague.tracker.network/profile/epic/'
     })
   end
 end

--- a/lib/RLDB.rb
+++ b/lib/RLDB.rb
@@ -227,7 +227,7 @@ class RLDB
     return if replays.empty?
 
     platform_map = {
-      ps4: 'ps',
+      ps4: 'psn',
       xbox: 'xbox',
       steam: 'steam',
       epic: 'epic'

--- a/lib/RLDB.rb
+++ b/lib/RLDB.rb
@@ -229,7 +229,8 @@ class RLDB
     platform_map = {
       ps4: 'ps',
       xbox: 'xbox',
-      steam: 'steam'
+      steam: 'steam',
+      epic: 'epic'
     }.freeze
     valid_player = lambda { |player|
       return player.id.id && platform_map.key?(player.id.platform.to_sym)

--- a/lib/RLRanks.rb
+++ b/lib/RLRanks.rb
@@ -83,7 +83,8 @@ class RLRanks
   RLT_PLATFORM_MAP = {
     xbox: :xbl,
     ps4: :psn,
-    steam: :steam
+    steam: :steam,
+    epic: :epic
   }.freeze
   private_constant :RLT_PLATFORM_MAP
 


### PR DESCRIPTION
This should use the same method that your XBox and PS use on rl tracker. All I did was add the support into your command , database, and pointed it to the correct links for tracker and rl stats. Anywhere you had xbox basically I added epic and its correspondents.