### PR TITLE
"ps4" platform input set to "ps"

### DIFF
--- a/bin/bot.rb
+++ b/bin/bot.rb
@@ -115,6 +115,7 @@ jubi.command(:register,
              aliases: %i[add signup],
              num_args: (2..3)) { |event, account_id, platform, region|
   platform.downcase!
+  platform = 'ps' if platform === 'ps4'
   region&.upcase!
   platform = platform.to_sym
   RLBot.validate_platform(platform)


### PR DESCRIPTION
# USER REGISTRATION MANAGEMENT
change "ps4" platform input to "ps"
may be a better place to add platform aliases if more show be added (I've only see people struggle with 'ps')
probably 80% of failed PlayStation registrations